### PR TITLE
rename tags to subjects in BookResultDto

### DIFF
--- a/src/main/java/com/samrice/readingroomapi/dtos/BookResultDto.java
+++ b/src/main/java/com/samrice/readingroomapi/dtos/BookResultDto.java
@@ -11,6 +11,6 @@ public record BookResultDto(
         Integer editionCount,
         List<BasicAuthor> authors,
         String coverUrl,
-        List<String> tags
+        List<String> subjects
 ) {
 }


### PR DESCRIPTION
Update `tags` field to `subjects` within BookResultDto.