### PR TITLE
Authentication Refactor: JWT Cookie Integration

### DIFF
--- a/src/main/java/com/samrice/readingroomapi/Constants.java
+++ b/src/main/java/com/samrice/readingroomapi/Constants.java
@@ -2,5 +2,5 @@ package com.samrice.readingroomapi;
 
 public class Constants {
     public static final String API_SECRET_KEY = "readingroomapikey";
-    public static final long TOKEN_VALIDITY_DURATION = 2 * 60 * 60 * 1000;
+    public static final long TOKEN_VALIDITY_DURATION_MS = 2 * 60 * 60 * 1000;
 }

--- a/src/main/java/com/samrice/readingroomapi/config/FilterConfig.java
+++ b/src/main/java/com/samrice/readingroomapi/config/FilterConfig.java
@@ -20,17 +20,17 @@ public class FilterConfig {
         return registrationBean;
     }
 
-    @Bean
-    public FilterRegistrationBean<CorsFilter> corsFilterFilterRegistrationBean() {
-        FilterRegistrationBean<CorsFilter> registrationBean = new FilterRegistrationBean<>();
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        CorsConfiguration config = new CorsConfiguration();
-        config.addAllowedOrigin("*");
-        config.addAllowedHeader("*");
-        source.registerCorsConfiguration("/**", config);
-        CorsFilter corsFilter = new CorsFilter(source);
-        registrationBean.setFilter(corsFilter);
-        registrationBean.setOrder(0);
-        return registrationBean;
-    }
+//    @Bean
+//    public FilterRegistrationBean<CorsFilter> corsFilterFilterRegistrationBean() {
+//        FilterRegistrationBean<CorsFilter> registrationBean = new FilterRegistrationBean<>();
+//        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+//        CorsConfiguration config = new CorsConfiguration();
+//        config.addAllowedOrigin("*");
+//        config.addAllowedHeader("*");
+//        source.registerCorsConfiguration("/**", config);
+//        CorsFilter corsFilter = new CorsFilter(source);
+//        registrationBean.setFilter(corsFilter);
+//        registrationBean.setOrder(0);
+//        return registrationBean;
+//    }
 }

--- a/src/main/java/com/samrice/readingroomapi/config/FilterConfig.java
+++ b/src/main/java/com/samrice/readingroomapi/config/FilterConfig.java
@@ -4,9 +4,6 @@ import com.samrice.readingroomapi.filters.AuthFilter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
 
 @Configuration
 public class FilterConfig {
@@ -19,18 +16,4 @@ public class FilterConfig {
         registrationBean.addUrlPatterns("/api/shelves/*");
         return registrationBean;
     }
-
-//    @Bean
-//    public FilterRegistrationBean<CorsFilter> corsFilterFilterRegistrationBean() {
-//        FilterRegistrationBean<CorsFilter> registrationBean = new FilterRegistrationBean<>();
-//        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-//        CorsConfiguration config = new CorsConfiguration();
-//        config.addAllowedOrigin("*");
-//        config.addAllowedHeader("*");
-//        source.registerCorsConfiguration("/**", config);
-//        CorsFilter corsFilter = new CorsFilter(source);
-//        registrationBean.setFilter(corsFilter);
-//        registrationBean.setOrder(0);
-//        return registrationBean;
-//    }
 }

--- a/src/main/java/com/samrice/readingroomapi/config/WebMvcConfig.java
+++ b/src/main/java/com/samrice/readingroomapi/config/WebMvcConfig.java
@@ -1,0 +1,18 @@
+package com.samrice.readingroomapi.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000")
+                .allowedMethods("*")
+                .allowedHeaders("Set-Cookie")
+                .allowCredentials(true);
+    }
+}

--- a/src/main/java/com/samrice/readingroomapi/config/WebMvcConfig.java
+++ b/src/main/java/com/samrice/readingroomapi/config/WebMvcConfig.java
@@ -11,8 +11,7 @@ public class WebMvcConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000")
-                .allowedMethods("*")
-                .allowedHeaders("Set-Cookie")
+                .allowedMethods("GET", "POST", "PUT", "DELETE")
                 .allowCredentials(true);
     }
 }

--- a/src/main/java/com/samrice/readingroomapi/controllers/UserController.java
+++ b/src/main/java/com/samrice/readingroomapi/controllers/UserController.java
@@ -6,12 +6,10 @@ import com.samrice.readingroomapi.services.UserService;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.Date;
 import java.util.HashMap;
@@ -41,7 +39,9 @@ public class UserController {
         String password = (String) userMap.get("password");
         User user = userService.validateUser(email, password);
         Map<String, Object> responseMap = this.createResponseMap(user);
-        return new ResponseEntity<>(responseMap, HttpStatus.OK);
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Set-Cookie", this.generateJWTToken(user));
+        return new ResponseEntity<>(responseMap, headers, HttpStatus.OK);
     }
 
     private String generateJWTToken(User user) {

--- a/src/main/java/com/samrice/readingroomapi/controllers/UserController.java
+++ b/src/main/java/com/samrice/readingroomapi/controllers/UserController.java
@@ -2,17 +2,18 @@ package com.samrice.readingroomapi.controllers;
 
 import com.samrice.readingroomapi.Constants;
 import com.samrice.readingroomapi.domains.User;
+import com.samrice.readingroomapi.dtos.UserDto;
 import com.samrice.readingroomapi.services.UserService;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Date;
-import java.util.HashMap;
 import java.util.Map;
 
 @RestController
@@ -23,49 +24,42 @@ public class UserController {
     UserService userService;
 
     @PostMapping("/register")
-    public ResponseEntity<Map<String, Object>> registerUser(@RequestBody Map<String, Object> userMap) {
+    public ResponseEntity<UserDto> registerUser(@RequestBody Map<String, Object> userMap, HttpServletResponse response) {
         String firstName = (String) userMap.get("firstName");
         String lastName = (String) userMap.get("lastName");
         String email = (String) userMap.get("email");
         String password = (String) userMap.get("password");
         User user = userService.registerUser(firstName, lastName, email, password);
-        Map<String, Object> responseMap = this.createResponseMap(user);
-        return new ResponseEntity<>(responseMap, HttpStatus.OK);
+        UserDto userDto = new UserDto(user.getEmail(), user.getFirstName(), user.getLastName());
+        response.addCookie(this.generateAuthCookie(user));
+        return new ResponseEntity<>(userDto, HttpStatus.OK);
     }
 
     @PostMapping("/login")
-    public ResponseEntity<Map<String, Object>> loginUser(@RequestBody Map<String, Object> userMap) {
+    public ResponseEntity<UserDto> loginUser(@RequestBody Map<String, Object> userMap, HttpServletResponse response) {
         String email = (String) userMap.get("email");
         String password = (String) userMap.get("password");
         User user = userService.validateUser(email, password);
-        Map<String, Object> responseMap = this.createResponseMap(user);
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Set-Cookie", this.generateJWTToken(user));
-        return new ResponseEntity<>(responseMap, headers, HttpStatus.OK);
+        UserDto userDto = new UserDto(user.getEmail(), user.getFirstName(), user.getLastName());
+        response.addCookie(this.generateAuthCookie(user));
+        return new ResponseEntity<>(userDto, HttpStatus.OK);
     }
 
-    private String generateJWTToken(User user) {
+    private Cookie generateAuthCookie(User user) {
         long timestamp = System.currentTimeMillis();
+        Date expiration = new Date(timestamp + Constants.TOKEN_VALIDITY_DURATION_MS);
         String token = Jwts.builder().signWith(SignatureAlgorithm.HS256, Constants.API_SECRET_KEY)
                 .setIssuedAt(new Date(timestamp))
-                .setExpiration(new Date(timestamp + Constants.TOKEN_VALIDITY_DURATION))
+                .setExpiration(expiration)
                 .claim("userId", user.getUserId())
                 .claim("firstName", user.getFirstName())
                 .claim("lastName", user.getLastName())
                 .claim("email", user.getEmail())
                 .compact();
-        return token;
-    }
-
-    private Map<String, Object> createResponseMap(User user) {
-        Map<String, Object> responseMap = new HashMap<>();
-        Map<String, Object> userData = new HashMap<>();
-        userData.put("userId", user.getUserId());
-        userData.put("firstName", user.getFirstName());
-        userData.put("lastName", user.getLastName());
-        userData.put("email", user.getEmail());
-        responseMap.put("token", this.generateJWTToken(user));
-        responseMap.put("userData", userData);
-        return responseMap;
+        Cookie cookie = new Cookie("token", token);
+        cookie.setMaxAge((int) Constants.TOKEN_VALIDITY_DURATION_MS / 100);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        return cookie;
     }
 }

--- a/src/main/java/com/samrice/readingroomapi/controllers/UserController.java
+++ b/src/main/java/com/samrice/readingroomapi/controllers/UserController.java
@@ -59,6 +59,7 @@ public class UserController {
         Cookie cookie = new Cookie("token", token);
         cookie.setMaxAge((int) Constants.TOKEN_VALIDITY_DURATION_MS / 100);
         cookie.setHttpOnly(true);
+        cookie.setPath("/");
         cookie.setSecure(true);
         return cookie;
     }

--- a/src/main/java/com/samrice/readingroomapi/dtos/UserDto.java
+++ b/src/main/java/com/samrice/readingroomapi/dtos/UserDto.java
@@ -1,0 +1,4 @@
+package com.samrice.readingroomapi.dtos;
+
+public record UserDto(String email, String firstName, String lastName) {
+}

--- a/src/main/java/com/samrice/readingroomapi/filters/AuthFilter.java
+++ b/src/main/java/com/samrice/readingroomapi/filters/AuthFilter.java
@@ -19,7 +19,6 @@ public class AuthFilter extends GenericFilterBean {
     public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
         HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
         HttpServletResponse httpResponse = (HttpServletResponse) servletResponse;
-
         String authHeader = httpRequest.getHeader("Authorization");
         if (authHeader != null) {
             String[] authHeaderArr = authHeader.split("Bearer ");


### PR DESCRIPTION
This branch adds new CORS configuration, `userDto` record, and changes the method of delivering JWT token to the client (from simply passing token in response body to now passing a cookie via `Set-Cookie` in response header).

New CORS configuration should still allow the API to be demoed from Postman, but will restrict browser access to http://localhost:3000.